### PR TITLE
Put debug menu on DPAD_LEFT where it belongs

### DIFF
--- a/src/dx/debug_menu.c
+++ b/src/dx/debug_menu.c
@@ -102,7 +102,7 @@ void dx_render_debug_menu(void) {
 
     // Don't render if the menu isn't visible
     if (!dx_debug_menu_isVisible) {
-        if (gGameStatus.pressedButtons[0] & BUTTON_D_RIGHT) {
+        if (gGameStatus.pressedButtons[0] & BUTTON_D_LEFT) {
             dx_debug_menu_isVisible = TRUE;
         }
 


### PR DESCRIPTION
Because I'm convinced alex only put it on DPAD_RIGHT to mess with SR users, and I will not stand for it.cd '/home/lenok/projects/papermario-dx'

﻿<!--
By submitting a pull request to pmret/papermario, you agree to give the
maintainers permission to use, alter, and distribute anything you contribute.
If you don't agree to this, please do not submit a PR.

Thank you for contributing to pmret/papermario!
--->
