### PR TITLE
Make Actor HP a s16 instead of s8

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ To get started, see [docs.starhaven.dev](https://docs.starhaven.dev/tools/decomp
 - Fixed many bugs / incorrect behaviour.
 - Skip compiling or linking dead code.
 - Link with [libgcc_vr4300] to provide compiler intrinsics.
+- Enemy HP is now a `s16`, increasing the cap to 32767.
 - Additional features can be configured in [src/dx/config.h](src/dx/config.h).
 
 [libgcc_vr4300]: https://github.com/Decompollaborate/libgcc_vr4300

--- a/include/common_structs.h
+++ b/include/common_structs.h
@@ -1887,9 +1887,8 @@ typedef struct Actor {
     /* 0x19B */ char unk_19B[1];
     /* 0x19C */ s32 actorTypeData1[6]; /* 4 = jump sound, 5 = attack sound */ // TODO: struct
     /* 0x1B4 */ s16 actorTypeData1b[2];
-    /* 0x1B8 */ s8 curHP;
-    /* 0x1B9 */ s8 maxHP;
-    /* 0x1BA */ char unk_1BA[2];
+    /* 0x1B8 */ s16 curHP;
+    /* 0x1BA */ s16 maxHP;
     /* 0x1BC */ s8 healthFraction; /* used to render HP bar */
     /* 0x1BD */ char unk_1BD[3];
     /* 0x1C0 */ EvtScript* idleSource;

--- a/src/battle/16C8E0.c
+++ b/src/battle/16C8E0.c
@@ -923,7 +923,6 @@ void btl_draw_enemy_health_bars(void) {
                             hud_element_draw_next(id);
 
                             if (currentHP < 10) {
-                                // we just drew the ones digit, we're done now
                                 break;
                             }
 

--- a/src/battle/16C8E0.c
+++ b/src/battle/16C8E0.c
@@ -899,6 +899,7 @@ void btl_draw_enemy_health_bars(void) {
                     if (enemy->healthBarPos.y >= -500) {
                         s32 screenX, screenY, screenZ;
                         s32 id;
+                        s32 nextDigitXOffset;
 
                         get_screen_coords(CAM_BATTLE, x, y, z, &screenX, &screenY, &screenZ);
                         screenY += 16;
@@ -908,26 +909,28 @@ void btl_draw_enemy_health_bars(void) {
                         hud_element_set_render_pos(id, screenX, screenY);
                         hud_element_draw_clipped(id);
 
-                        temp = currentHP / 10;
-                        ones = currentHP % 10;
-
-                        // tens digit
-                        if (temp > 0) {
-                            id = D_8029EFBC;
-                            hud_element_set_render_depth(id, 10);
-                            hud_element_set_script(id, bHPDigitHudScripts[temp]);
-                            btl_draw_prim_quad(0, 0, 0, 0, screenX, screenY + 2, 8, 8);
-                            hud_element_set_render_pos(id, screenX + 4, screenY + 6);
-                            hud_element_draw_next(id);
-                        }
-
-                        // ones digit
+                        #define DIGIT_WIDTH 6
+                        nextDigitXOffset = DIGIT_WIDTH;
                         id = D_8029EFBC;
-                        hud_element_set_render_depth(id, 10);
-                        hud_element_set_script(id, bHPDigitHudScripts[ones]);
-                        btl_draw_prim_quad(0, 0, 0, 0, screenX + 6, screenY + 2, 8, 8);
-                        hud_element_set_render_pos(id, screenX + 10, screenY + 6);
-                        hud_element_draw_next(id);
+                        // draw all digits
+                        while (TRUE) {
+                            s32 digit = currentHP % 10;
+
+                            hud_element_set_render_depth(id, 10);
+                            hud_element_set_script(id, bHPDigitHudScripts[digit]);
+                            btl_draw_prim_quad(0, 0, 0, 0, screenX + nextDigitXOffset, screenY + 2, 8, 8);
+                            hud_element_set_render_pos(id, screenX + nextDigitXOffset + 4, screenY + 6);
+                            hud_element_draw_next(id);
+
+                            if (currentHP < 10) {
+                                // we just drew the ones digit, we're done now
+                                break;
+                            }
+
+                            currentHP /= 10;
+                            nextDigitXOffset -= DIGIT_WIDTH;
+                        }
+                        #undef DIGIT_WIDTH
 
                         temp = enemy->healthFraction;
                         temp = 25 - temp;

--- a/src/battle/battle.h
+++ b/src/battle/battle.h
@@ -132,7 +132,7 @@ typedef struct ActorBlueprint {
     /* 0x04 */ char unk_04;
     /* 0x05 */ u8 type;
     /* 0x06 */ u8 level;
-    /* 0x07 */ u8 maxHP;
+    /* 0x07 */ s16 maxHP;
     /* 0x08 */ s16 partCount;
     /* 0x0A */ char unk_0A[2];
     /* 0x0C */ struct ActorPartBlueprint* partsData;

--- a/src/battle/battle.h
+++ b/src/battle/battle.h
@@ -129,10 +129,9 @@ typedef struct BattleMoveEntry {
 
 typedef struct ActorBlueprint {
     /* 0x00 */ s32 flags;
-    /* 0x04 */ char unk_04;
-    /* 0x05 */ u8 type;
-    /* 0x06 */ u8 level;
-    /* 0x07 */ s16 maxHP;
+    /* 0x04 */ s16 maxHP;
+    /* 0x06 */ u8 type;
+    /* 0x07 */ u8 level;
     /* 0x08 */ s16 partCount;
     /* 0x0A */ char unk_0A[2];
     /* 0x0C */ struct ActorPartBlueprint* partsData;


### PR DESCRIPTION
Adds support for actor hp being a s16 instead of s8. `btl_draw_enemy_health_bars` has been partially rewritten to support drawing arbitrarily large numbers.
