### PR TITLE
Implement negative bp badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ To get started, see [docs.starhaven.dev](https://docs.starhaven.dev/tools/decomp
 - Skip compiling or linking dead code.
 - Link with [libgcc_vr4300] to provide compiler intrinsics.
 - Enemy HP is now a `s16`, increasing the cap to 32767.
+- Added support for badges with negative BP costs.
 - Additional features can be configured in [src/dx/config.h](src/dx/config.h).
 
 [libgcc_vr4300]: https://github.com/Decompollaborate/libgcc_vr4300

--- a/src/msg.c
+++ b/src/msg.c
@@ -2270,7 +2270,7 @@ void draw_number(s32 value, s32 x, s32 y, s32 charset, s32 palette, s32 opacity,
 
         // handle negative numbers
         if (valueStr[i] == '-') {
-            digits[i] = 0xD - 0x10; // the "0" char has an id of 0x10, while "-" has an id of 0xD in the pm font format
+            digits[i] = MSG_CHAR_MINUS - MSG_CHAR_DIGIT_0;
             continue;
         }
 

--- a/src/msg.c
+++ b/src/msg.c
@@ -2245,7 +2245,7 @@ void draw_digit(IMG_PTR img, s32 charset, s32 posX, s32 posY) {
 
 void draw_number(s32 value, s32 x, s32 y, s32 charset, s32 palette, s32 opacity, u16 style) {
     u8 valueStr[24];
-    u8 digits[24];
+    s8 digits[24];
     s32 digitPosX[24];
     s32 i;
     s32 count;
@@ -2268,6 +2268,12 @@ void draw_number(s32 value, s32 x, s32 y, s32 charset, s32 palette, s32 opacity,
             break;
         }
 
+        // handle negative numbers
+        if (valueStr[i] == '-') {
+            digits[i] = 0xD - 0x10; // the "0" char has an id of 0x10, while "-" has an id of 0xD in the pm font format
+            continue;
+        }
+
         digit = valueStr[i] - '0';
         if (digit < 10){
             digits[i] = digit;
@@ -2280,7 +2286,7 @@ void draw_number(s32 value, s32 x, s32 y, s32 charset, s32 palette, s32 opacity,
 
     if (style & DRAW_NUMBER_STYLE_ALIGN_RIGHT) {
         for (i = count - 1; i >= 0; i--) {
-            if (style & DRAW_NUMBER_STYLE_MONOSPACE) {
+            if ((style & DRAW_NUMBER_STYLE_MONOSPACE) || digits[i] < 0) {
                 posX -= gMsgNumbers[charset].fixedWidth;
             } else {
                 posX -= gMsgNumbers[charset].digitWidth[digits[i]];
@@ -2290,7 +2296,7 @@ void draw_number(s32 value, s32 x, s32 y, s32 charset, s32 palette, s32 opacity,
     } else {
         for (i = 0; i < count; i++) {
             digitPosX[i] = posX;
-            if (style & DRAW_NUMBER_STYLE_MONOSPACE) {
+            if ((style & DRAW_NUMBER_STYLE_MONOSPACE) || digits[i] < 0) {
                 posX += gMsgNumbers[charset].fixedWidth;
             } else {
                 posX += gMsgNumbers[charset].digitWidth[digits[i]];


### PR DESCRIPTION
Adds support for negative BP badges:
- If you need the BP added by these badges to equip other badges, you may not unequip a negative cost badge.
- Fixes rendering for negative numbers in `draw_number`.