### PR TITLE
more fixes

### DIFF
--- a/src/23680.c
+++ b/src/23680.c
@@ -174,7 +174,12 @@ void spawn_drops(Enemy* enemy) {
 
     dropCount = 0;
     itemToDrop = ITEM_NONE;
-    fraction = playerData->curFP / (f32) playerData->curMaxFP;
+
+    if (playerData->curMaxFP > 0) {
+        fraction = playerData->curFP / (f32) playerData->curMaxFP;
+    } else {
+        fraction = 0.0;
+    }
 
     for (i = 0; i < 8; i++) {
         attempts  = drops->flowerDrops[4 * i + 0];

--- a/src/battle/btl_states_menus.c
+++ b/src/battle/btl_states_menus.c
@@ -2539,10 +2539,15 @@ void btl_state_update_player_menu(void) {
                             s32 moveID = gItemTable[playerData->equippedBadges[i]].moveID;
                             moveData = &gMoveTable[moveID];
                             if (moveData->category == BattleMenu_CategoryForSubmenu[battleStatus->curSubmenu]) {
+                                s32 cost = moveData->costFP;
                                 battleStatus->submenuMoves[entryIdx] = moveID;
                                 battleStatus->submenuIcons[entryIdx] = playerData->equippedBadges[i];
                                 battleStatus->submenuStatus[entryIdx] = 1;
-                                if (playerData->curFP < moveData->costFP) {
+
+                                cost -= player_team_is_ability_active(playerActor, ABILITY_FLOWER_SAVER);
+                                cost -= 2 * player_team_is_ability_active(playerActor, ABILITY_FLOWER_FANATIC);
+
+                                if (playerData->curFP < cost) {
                                     battleStatus->submenuStatus[entryIdx] = 0;
                                 }
                                 entryIdx++;

--- a/src/entity/Block.c
+++ b/src/entity/Block.c
@@ -357,7 +357,18 @@ s32 entity_block_handle_collision(Entity* entity) {
         }
         return TRUE;
     }
+
     if (entity->collisionFlags & ENTITY_COLLISION_PARTNER) {
+        // partner collision means either kooper shell toss or bombette explosion
+        if (gPlayerData.curPartner == PARTNER_BOMBETTE) {
+            switch (get_entity_type(entity->listIndex)) {
+                case ENTITY_TYPE_HAMMER1_BLOCK:
+                case ENTITY_TYPE_HAMMER1_BLOCK_TINY:
+                    set_entity_commandlist(entity, Entity_BreakingBlock_Script);
+                    sfx_play_sound_at_position(SOUND_SMASH_HAMER_BLOCK_1, SOUND_SPACE_DEFAULT, entity->pos.x, entity->pos.y, entity->pos.z);
+                    return TRUE;
+            }
+        }
         exec_entity_commandlist(entity);
         return TRUE;
     }


### PR DESCRIPTION
prevent crash when maxFP = 0
take flower saver into account when using douple dip
bombette destroys hammer blocks without having to reload map